### PR TITLE
Fix default options overriding

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const defaults = {
 
 function init(i18next, $, options = {}) {
 
-  options = { ...options, ...defaults };
+  options = { ...defaults, ...options };
 
   function parse(ele, key, opts) {
     if (key.length === 0) return;


### PR DESCRIPTION
Defaults were being set after user-supplied options, overriding them. Swap the order.
