### PR TITLE
Fix download link on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Source can be loaded via [npm](https://www.npmjs.com/package/jquery-i18next), bower or [downloaded](https://github.com/i18next/jquery-i18next/blob/master/i18next-jquery.min.js) from this repo.
+Source can be loaded via [npm](https://www.npmjs.com/package/jquery-i18next), bower or [downloaded](https://github.com/i18next/jquery-i18next/blob/master/jquery-i18next.min.js) from this repo.
 
 If you don't use a module loader it will be added to window.jqueryI18next
 


### PR DESCRIPTION
The current download link is pointing to the wrong place. So, this PR update the link to point to the proper URL, which is: https://github.com/i18next/jquery-i18next/blob/master/jquery-i18next.min.js